### PR TITLE
Support for cross-namespace .allowedClients

### DIFF
--- a/appconfigmgrv2/config/crd/bases/appconfigmgr.cft.dev_appenvconfigtemplatev2s.yaml
+++ b/appconfigmgrv2/config/crd/bases/appconfigmgr.cft.dev_appenvconfigtemplatev2s.yaml
@@ -1,16 +1,4 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/appconfigmgrv2/config/rbac/role.yaml
+++ b/appconfigmgrv2/config/rbac/role.yaml
@@ -1,16 +1,4 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/appconfigmgrv2/config/webhook/manifests.yaml
+++ b/appconfigmgrv2/config/webhook/manifests.yaml
@@ -1,16 +1,4 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.s
+
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/appconfigmgrv2/controllers/istio_handlers.go
+++ b/appconfigmgrv2/controllers/istio_handlers.go
@@ -16,6 +16,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appconfig "github.com/GoogleCloudPlatform/anthos-appconfig/appconfigmgrv2/api/v1alpha1"
 
@@ -62,34 +63,35 @@ func (r *AppEnvConfigTemplateV2Reconciler) reconcileIstioHandlers(
 func istioHandlers(cfg Config, t *appconfig.AppEnvConfigTemplateV2) ([]*unstructured.Unstructured, error) {
 	list := make([]*unstructured.Unstructured, 0, len(t.Spec.Services))
 	for i := range t.Spec.Services {
-		appWhitelist, err := istioAppWhitelistHandler(cfg, t, i)
+		wl, err := istioWhitelistHandler(cfg, t, i)
 		if err != nil {
-			return nil, fmt.Errorf("new app whitelist: %v", err)
-		}
-		nsWhitelist, err := istioNamespaceWhitelistHandler(cfg, t, i)
-		if err != nil {
-			return nil, fmt.Errorf("new namespace whitelist: %v", err)
+			return nil, fmt.Errorf("building whitelist: %v", err)
 		}
 
-		list = append(list, appWhitelist, nsWhitelist)
+		list = append(list, wl)
 	}
 
 	return list, nil
 }
 
-// istioAppWhitelistHandler creates a handler that whitelists client apps.
-func istioAppWhitelistHandler(
+// istioWhitelistHandler creates a handler that whitelists client apps.
+func istioWhitelistHandler(
 	cfg Config,
 	t *appconfig.AppEnvConfigTemplateV2,
 	i int,
 ) (*unstructured.Unstructured, error) {
 	var allowedClients types.ListValue
 	for _, allowed := range t.Spec.Services[i].AllowedClients {
-		allowedClients.Values = append(allowedClients.Values, &types.Value{Kind: &types.Value_StringValue{StringValue: allowed.Name}})
+		val := allowed.Name
+		if !strings.Contains(val, "/") {
+			// Append a default namespace.
+			val = t.Namespace + "/" + val
+		}
+		allowedClients.Values = append(allowedClients.Values, &types.Value{Kind: &types.Value_StringValue{StringValue: val}})
 	}
 
 	meta := map[string]interface{}{
-		"name":      istioAppWhitelistHandlerName(t, i),
+		"name":      istioWhitelistHandlerName(t, i),
 		"namespace": t.Namespace,
 	}
 	spec := &istiopolicy.Handler{
@@ -106,43 +108,8 @@ func istioAppWhitelistHandler(
 	return unstructuredFromProto(istioHandlerGVK(), meta, spec)
 }
 
-// istioNamespaceWhitelistHandler builds a handler that whitelists the current namespace.
-func istioNamespaceWhitelistHandler(
-	cfg Config,
-	t *appconfig.AppEnvConfigTemplateV2,
-	i int,
-) (*unstructured.Unstructured, error) {
-	allowedNamespaces := &types.ListValue{
-		Values: []*types.Value{&types.Value{Kind: &types.Value_StringValue{StringValue: t.Namespace}}},
-	}
-
-	meta := map[string]interface{}{
-		"name":      istioNamespaceWhitelistHandlerName(t, i),
-		"namespace": t.Namespace,
-	}
-	spec := &istiopolicy.Handler{
-		CompiledAdapter: "listchecker",
-		Params: &types.Struct{
-			Fields: map[string]*types.Value{
-				"overrides":       {Kind: &types.Value_ListValue{ListValue: allowedNamespaces}},
-				"blacklist":       {Kind: &types.Value_BoolValue{BoolValue: false}},
-				"cachingInterval": {Kind: &types.Value_StringValue{StringValue: cfg.PolicyCachingInterval}},
-			},
-		},
-	}
-
-	return unstructuredFromProto(istioHandlerGVK(), meta, spec)
-}
-
-func istioAppWhitelistHandlerName(t *appconfig.AppEnvConfigTemplateV2, i int) string {
-	return fmt.Sprintf("%v-app-whitelist--%v",
-		t.Name,
-		t.Spec.Services[i].Name,
-	)
-}
-
-func istioNamespaceWhitelistHandlerName(t *appconfig.AppEnvConfigTemplateV2, i int) string {
-	return fmt.Sprintf("%v-namespace-whitelist--%v",
+func istioWhitelistHandlerName(t *appconfig.AppEnvConfigTemplateV2, i int) string {
+	return fmt.Sprintf("%v-whitelist--%v",
 		t.Name,
 		t.Spec.Services[i].Name,
 	)

--- a/appconfigmgrv2/controllers/istio_handlers_test.go
+++ b/appconfigmgrv2/controllers/istio_handlers_test.go
@@ -30,10 +30,7 @@ func TestIstioHandlers(t *testing.T) {
 
 	list, err := istioHandlers(cfg, in)
 	require.NoError(t, err)
-	// There should be 2 handlers for each service:
-	// 1. The apps that can call it
-	// 2. The namespaces that can call it
-	require.Len(t, list, 2*len(in.Spec.Services))
+	require.Len(t, list, len(in.Spec.Services))
 
 	gvr := istioHandlerGVR()
 

--- a/appconfigmgrv2/controllers/istio_instances.go
+++ b/appconfigmgrv2/controllers/istio_instances.go
@@ -40,21 +40,10 @@ func (r *AppEnvConfigTemplateV2Reconciler) reconcileIstioInstances(
 		return err
 	}
 
-	nsInst, err := istioNamespaceInstance(in)
-	if err != nil {
-		return fmt.Errorf("building: %v", err)
-	}
-	if err := controllerutil.SetControllerReference(in, nsInst, r.Scheme); err != nil {
-		return err
-	}
-
 	gvr := istioInstanceGVR()
 
 	if err := r.upsertUnstructured(ctx, appLabelInst, gvr); err != nil {
 		return fmt.Errorf("reconciling app label instance: %v", err)
-	}
-	if err := r.upsertUnstructured(ctx, nsInst, gvr); err != nil {
-		return fmt.Errorf("reconciling namespace instance: %v", err)
 	}
 
 	return nil
@@ -71,27 +60,7 @@ func istioAppLabelInstance(t *appconfig.AppEnvConfigTemplateV2) (*unstructured.U
 			CompiledTemplate: "listentry",
 			Params: &types.Struct{
 				Fields: map[string]*types.Value{
-					"value": {Kind: &types.Value_StringValue{StringValue: `source.labels["app"]`}},
-				},
-			},
-		}
-	)
-
-	return unstructuredFromProto(gvk, meta, spec)
-}
-
-func istioNamespaceInstance(t *appconfig.AppEnvConfigTemplateV2) (*unstructured.Unstructured, error) {
-	var (
-		gvk  = istioInstanceGVK()
-		meta = map[string]interface{}{
-			"name":      istioNamespaceInstanceName(t),
-			"namespace": t.Namespace,
-		}
-		spec = &v1beta1.Instance{
-			CompiledTemplate: "listentry",
-			Params: &types.Struct{
-				Fields: map[string]*types.Value{
-					"value": {Kind: &types.Value_StringValue{StringValue: `source.namespace`}},
+					"value": {Kind: &types.Value_StringValue{StringValue: `source.namespace + "/" + source.labels["app"]`}},
 				},
 			},
 		}
@@ -102,10 +71,6 @@ func istioNamespaceInstance(t *appconfig.AppEnvConfigTemplateV2) (*unstructured.
 
 func istioAppLabelInstanceName(t *appconfig.AppEnvConfigTemplateV2) string {
 	return fmt.Sprintf("%v-applabel", t.Name)
-}
-
-func istioNamespaceInstanceName(t *appconfig.AppEnvConfigTemplateV2) string {
-	return fmt.Sprintf("%v-namespace", t.Name)
 }
 
 func istioInstanceGVK() schema.GroupVersionKind {

--- a/appconfigmgrv2/controllers/istio_instances_test.go
+++ b/appconfigmgrv2/controllers/istio_instances_test.go
@@ -27,15 +27,8 @@ func TestIstioInstances(t *testing.T) {
 
 	gvr := istioInstanceGVR()
 
-	// App-label instance.
 	appLabelInst, err := istioAppLabelInstance(in)
 	require.NoError(t, err)
 
 	unstructuredShouldExist(t, r.Dynamic, gvr, appLabelInst)
-
-	// Namespace instance.
-	nsInst, err := istioNamespaceInstance(in)
-	require.NoError(t, err)
-
-	unstructuredShouldExist(t, r.Dynamic, gvr, nsInst)
 }

--- a/appconfigmgrv2/controllers/istio_rules.go
+++ b/appconfigmgrv2/controllers/istio_rules.go
@@ -73,8 +73,7 @@ func istioRules(cfg Config, t *appconfig.AppEnvConfigTemplateV2) ([]*unstructure
 		spec := &v1beta1.Rule{
 			Match: fmt.Sprintf(`destination.labels["app"] == "%v"`, t.Spec.Services[i].Name),
 			Actions: []*v1beta1.Action{
-				{Handler: istioAppWhitelistHandlerName(t, i), Instances: []string{istioAppLabelInstanceName(t)}},
-				{Handler: istioNamespaceWhitelistHandlerName(t, i), Instances: []string{istioNamespaceInstanceName(t)}},
+				{Handler: istioWhitelistHandlerName(t, i), Instances: []string{istioAppLabelInstanceName(t)}},
 			},
 		}
 


### PR DESCRIPTION
Backwards compatible: You can now use `<namespace>/<app>` notation in `.allowedClients`.