### PR TITLE
Remove empty patch ref

### DIFF
--- a/appconfigmgrv2/config/crd/kustomization.yaml
+++ b/appconfigmgrv2/config/crd/kustomization.yaml
@@ -25,9 +25,9 @@ resources:
 - bases/appconfigmgr.cft.dev_appenvconfigtemplatev2s.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+# patches:
 # [WEBHOOK] patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_appenvconfigtemplatev2s.yaml
+# - patches/webhook_in_appenvconfigtemplatev2s.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CAINJECTION] patches here are for enabling the CA injection for each CRD


### PR DESCRIPTION
Kustomize (v3.1.0) was failing. Removed empty patch reference.

```
$ make kustomize
mkdir -p config/generated
kustomize build config/default > config/generated/all.yaml
Error: accumulating resources: recursed accumulation of path '../crd': builtin patchStrategicMerge config: [112 97 116 104 115 58 10 45 32 112 97 116 99 104 101 115 47 119 101 98 104 111 111 107 95 105 110 95 97 112 112 101 110 118 99 111 110 102 105 103 116 101 109 112 108 97 116 101 118 50 115 46 121 97 109 108 10]: patch appears to be empty; files=[patches/webhook_in_appenvconfigtemplatev2s.yaml], Patch=
make: *** [kustomize] Error 1
```
http://b/138930441