### PR TITLE
Fix OPA test failure

### DIFF
--- a/scripts/crd-setup-helper.sh
+++ b/scripts/crd-setup-helper.sh
@@ -525,8 +525,9 @@ install_gatekeeper() {
   gsutil cat ${GATEKEEPER_BUCKET}/constraint-templates.yaml | kubectl apply -f -
 
   n=0
-  until [ $n -ge 10 ]
+  until [ $n -ge 50 ]
   do
+    echo "attempting to install constraints (attempt $n)"
     gsutil cat ${GATEKEEPER_BUCKET}/constraints.yaml | kubectl apply -f - && break
     n=$[$n+1]
     sleep 20


### PR DESCRIPTION
- Add sleep to allow gatekeeper to make crds