### PR TITLE
Bug 140250222 workload identity test failure

### DIFF
--- a/tests/artifacts/drivers/simple_hello/test/test_simple_hello.py
+++ b/tests/artifacts/drivers/simple_hello/test/test_simple_hello.py
@@ -328,7 +328,7 @@ class SimpleHelloTestCase(unittest.TestCase):
         self.workload_identity_pubsub_ok()
         time.sleep(5)
         break
-      except unittest.AssertionError:
+      except:
         retries -= 1
     if retries == 0:
       self.workload_identity_pubsub_ok()


### PR DESCRIPTION
Workload identity test fix: Appears that the first call sometimes fails with an unauthenticated response probably due to a timing issue. Added retry into test.