### PR TITLE
Anthos1.1 update

### DIFF
--- a/appconfigmgrv2/README.md
+++ b/appconfigmgrv2/README.md
@@ -29,3 +29,16 @@ func TestSomething(t *testing.T) {
 
 End-to-end tests are defined at `$REPO_ROOT/tests`. They are written in python and executed on GCP via a cloudbuild job.
 
+## Environment (go 1.12)
+
+```bash
+cd ./appconfigmgrv2
+export KUBECONFIG= # for make commands that do deployment during testing locally
+export GO111MODULE=on
+export GOPATH= # - e.g. /Users/joseret/go112
+export PATH=$PATH:/usr/local/kubebuilder2/bin # add kubebuilder
+```
+
+1. rm go.mod and go.sum
+2. go mod init
+3. go get sigs.k8s.io/controller-runtime@v0.2.0-beta.2

--- a/scripts/crd-setup-helper.sh
+++ b/scripts/crd-setup-helper.sh
@@ -29,7 +29,7 @@ set -e
 GATEKEEPER_BUCKET="gs://anthos-appconfig_public/acm/anthos-config-management/${RELEASE_NAME}/gatekeeper-config"
 TEMPLATE_BUCKET="gs://anthos-appconfig_public/acm/anthos-config-management/${RELEASE_NAME}/acm-crd/config-management-root"
 EXAMPLES_BUCKET="gs://anthos-appconfig_public/acm/anthos-config-management/${RELEASE_NAME}/acm-crd-examples/config-management-root"
-CM_OPERATOR_BUCKET="gs://config-management-release/released/latest/config-management-operator.yaml"
+CM_OPERATOR_BUCKET="gs://config-management-release/released/1.1.0/config-management-operator.yaml"
 HELM_IMAGE="alpine/helm:2.13.1"
 CM_CRD_COUNT=8
 
@@ -513,8 +513,6 @@ pre-install() {
 
 install_operator() {
   _output "installing config management operator to cluster"
-  gsutil ls ${CM_OPERATOR_BUCKET} || gsutil cat "gs://anthos-appconfig_build/sw/acm/config-management-operator.yaml"  | kubectl \
-    apply -f - || _errexit "No access to config management operator, whitelisted?"
   gsutil ls ${CM_OPERATOR_BUCKET} && gsutil cat ${CM_OPERATOR_BUCKET} | kubectl apply -f -
 }
 


### PR DESCRIPTION
Pin the ACM version in the installer and changes due to some timing of the tests with new http ingress that must be looked into later.