### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/tests/setup/cloudbuild.yaml
+++ b/tests/setup/cloudbuild.yaml
@@ -337,7 +337,6 @@ steps:
           --enable-network-policy \
           --enable-private-nodes \
           --enable-stackdriver-kubernetes \
-          --image-type "COS" \
           --machine-type "n1-standard-4" \
           --master-ipv4-cidr "172.$${PARM_SUBNET_MASTER}.0.0/28" \
           --metadata disable-legacy-endpoints=true \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.